### PR TITLE
👔 [add] 상품 비교 페이지 기능 추가

### DIFF
--- a/src/pages/ProductPage/ProductComparePage/ProductComparePage.tsx
+++ b/src/pages/ProductPage/ProductComparePage/ProductComparePage.tsx
@@ -1,43 +1,295 @@
 import * as styled from "../styles";
-import Header from "../../../layout/Header";
 import plus from "../../../assets/icon/plus.png";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+//components
+import Header from "../../../layout/Header";
 import Select from "../../../ui/Select";
+import BlueButton from "../../../ui/BlueBtn";
+
+
+// 상품 타입 정의
+interface Product {
+    area: string;
+    company: string;
+    product: string;
+    productType: string;
+    rcvMethod: string;
+    feeType: string;
+    sells: string;
+    withdraws: string;
+    guarantees: string;
+    currentBalance: string;
+    previousYearBalance: string;
+    twoYearsAgoBalance: string;
+    threeYearsAgoBalance: string;
+    currentReserve: string;
+    previousYearReserve: string;
+    twoYearsAgoReserve: string;
+    threeYearsAgoReserve: string;
+    currentEarnRate: number;
+    previousYearEarnRate: number;
+    twoYearsAgoEarnRate: number;
+    threeYearsAgoEarnRate: number;
+    previousYearFeeRate: number;
+    twoYearsAgoFeeRate: number;
+    threeYearsAgoFeeRate: number;
+}
+interface ProductData {
+    Balance: string;
+    Reserve: string;
+    EarnRate: string;
+    FeeRate: string;
+}
+
+// Mock 데이터
+const PRODUCT_LIST: Product[] = [
+    {
+        area: "은행",
+        company: "신한은행",
+        product: "연금저축신탁 안정형 제1호",
+        productType: "안정형",
+        rcvMethod: "연금 수령시 선택형",
+        feeType: "증가형",
+        sells: "중단",
+        withdraws: "가능",
+        guarantees: "보장",
+        currentBalance: "850,279",
+        previousYearBalance: "950,710",
+        twoYearsAgoBalance: "1,109,867",
+        threeYearsAgoBalance: "1,362,391",
+        currentReserve: "1,232,822",
+        previousYearReserve: "1,287,607",
+        twoYearsAgoReserve: "1,373,802",
+        threeYearsAgoReserve: "1,650,997",
+        currentEarnRate: 7.88,
+        previousYearEarnRate: 7.12,
+        twoYearsAgoEarnRate: -1.85,
+        threeYearsAgoEarnRate: -0.05,
+        previousYearFeeRate: 0.73,
+        twoYearsAgoFeeRate: 0.69,
+        threeYearsAgoFeeRate: 0.77
+    }, {
+        area: "은행",
+        company: "신한은행",
+        product: "연금저축신탁 안정형 제1호",
+        productType: "안정형",
+        rcvMethod: "연금 수령시 선택형",
+        feeType: "증가형",
+        sells: "중단",
+        withdraws: "가능",
+        guarantees: "보장",
+        currentBalance: "850,279",
+        previousYearBalance: "950,710",
+        twoYearsAgoBalance: "1,109,867",
+        threeYearsAgoBalance: "1,362,391",
+        currentReserve: "1,232,822",
+        previousYearReserve: "1,287,607",
+        twoYearsAgoReserve: "1,373,802",
+        threeYearsAgoReserve: "1,650,997",
+        currentEarnRate: 7.88,
+        previousYearEarnRate: 7.12,
+        twoYearsAgoEarnRate: -1.85,
+        threeYearsAgoEarnRate: -0.05,
+        previousYearFeeRate: 0.73,
+        twoYearsAgoFeeRate: 0.69,
+        threeYearsAgoFeeRate: 0.77
+    }]
+
+// 비교 항목 컴포넌트
+interface CompareRowProps {
+    label: string;
+    firstValue?: string | number;
+    secondValue?: string | number;
+    suffix?: string;
+}
+
+function CompareRow({ label, firstValue, secondValue, suffix = "" }: CompareRowProps) {
+    return (
+        <>
+            <styled.CompareItemText>{label}</styled.CompareItemText>
+            <styled.CompareItemTextContainer>
+                <p>{firstValue}{suffix}</p>
+                <p>{secondValue}{suffix}</p>
+            </styled.CompareItemTextContainer>
+        </>
+    );
+}
+
+// 연도별 데이터 행 컴포넌트
+interface YearlyDataRowProps {
+    label: string;
+    firstProduct?: Product;
+    secondProduct?: Product;
+    dataKey: keyof ProductData;
+    suffix?: string;
+}
+
+function YearlyDataRow({ label, firstProduct, secondProduct, dataKey, suffix = "" }: YearlyDataRowProps) {
+    return (
+        <>
+            <styled.CompareItemText>{label}</styled.CompareItemText>
+            <styled.CompareItemTextContainer>
+                <p>
+                    {firstProduct && ['current', 'previousYear', 'twoYearsAgo', 'threeYearsAgo'].map((period) => (
+                        <div key={period}>
+                            <span>{period === 'current' ? '현재' :
+                                period === 'previousYear' ? '과거 1년' :
+                                    period === 'twoYearsAgo' ? '과거 2년' : '과거 3년'}</span>
+                            <span>{firstProduct[`${period}${dataKey}` as keyof Product] ?? ''}{suffix}</span>
+                        </div>
+                    ))}
+                </p>
+                <p>
+                    {secondProduct && ['current', 'previousYear', 'twoYearsAgo', 'threeYearsAgo'].map((period) => (
+                        <div key={period}>
+                            <span>{period === 'current' ? '현재' :
+                                period === 'previousYear' ? '과거 1년' :
+                                    period === 'twoYearsAgo' ? '과거 2년' : '과거 3년'}</span>
+                            <span>{secondProduct[`${period}${dataKey}` as keyof Product] ?? ''}{suffix}</span>
+                        </div>
+                    ))}
+                </p>
+            </styled.CompareItemTextContainer>
+        </>
+    );
+}
 
 function ProductComparePage() {
+    const navigate = useNavigate();
+    const [firstProduct, setFirstProduct] = useState<Product | undefined>(undefined);
+    const [secondProduct, setSecondProduct] = useState<Product | undefined>(undefined);
+    const [activeTab, setActiveTab] = useState<string | undefined>('연금저축');
+    const searchParams = new URLSearchParams(window.location.search);
+    const firstProductId = searchParams.get('firstProduct');
+    const secondProductId = searchParams.get('secondProduct');
+    const activeType = searchParams.get('activeType');
+
+    useEffect(() => {
+        if (firstProductId) {
+            setFirstProduct(PRODUCT_LIST[Number(firstProductId) - 1]);
+        }
+    }, [firstProductId]);
+
+    useEffect(() => {
+        if (secondProductId) {
+            setSecondProduct(PRODUCT_LIST[Number(secondProductId) - 1]);
+        }
+    }, [secondProductId]);
+
+    useEffect(() => {
+        if (activeType) {
+            setActiveTab(activeType);
+        }
+    }, [activeType]);
+
+    const handleTabSelect = (type: string) => {
+        setActiveTab(type);
+    }
+
+    const handleFirstProduct = () => {
+        // secondProduct가 있다면 유지하면서 이동
+        const query = secondProductId ? `activeType=${activeTab}&action=selectFirstProduct&secondProduct=${secondProductId}` : `activeType=${activeTab}&action=selectFirstProduct`;
+        navigate(`/product/search?${query}`);
+    };
+
+    const handleSecondProduct = () => {
+        // firstProduct가 있다면 유지하면서 이동
+        const query = firstProductId ? `activeType=${activeTab}&action=selectSecondProduct&firstProduct=${firstProductId}` : `activeType=${activeTab}&action=selectSecondProduct`;
+        navigate(`/product/search?${query}`);
+    };
+
+    const renderProductSelector = (product: Product | undefined, onClick: () => void) => {
+        return (
+            <styled.CompareItem onClick={onClick}>
+                {!product ? (
+                    <>
+                        <styled.CompareButton>
+                            <img src={plus} alt="plus" />
+                        </styled.CompareButton>
+                        <styled.CompareButtonText>상품을 선택해주세요.</styled.CompareButtonText>
+                    </>
+                ) : (
+                    <>
+                        <p>{product.area}</p>
+                        <p>{product.product}</p>
+                        <p>{product.company}</p>
+                        <BlueButton variant="small" style={{ width: "100px" }} onClick={() => navigate(`/product/detail/0`)}>상품 상세</BlueButton>
+                    </>
+                )}
+            </styled.CompareItem>
+        )
+    }
+
     return (
         <styled.Container>
             <Header title="상품 비교" />
-            <styled.TitleContainer>
-                <styled.Title>상품 선택 후 비교할 수 있어요.</styled.Title>
-                <styled.SubTitle>아래 상자를 터치하여 비교할 상품을 선택해주세요.</styled.SubTitle>
-            </styled.TitleContainer>
-            <Select items={["연금저축", "퇴직연금"]} />
+            {!firstProduct && (
+                <>
+                    <styled.TitleContainer>
+                        <styled.Title>상품 선택 후 비교할 수 있어요.</styled.Title>
+                        <styled.SubTitle>아래 상자를 터치하여 비교할 상품을 선택해주세요.</styled.SubTitle>
+                    </styled.TitleContainer>
+                    <Select items={["연금저축", "퇴직연금"]} onSelect={handleTabSelect} />
+                </>
+            )}
+
             <styled.CompareContainer>
-                <styled.CompareItem style={{borderRight:"1px solid #b8b8b8"}}>
-                    <div>
-                        <img src={plus} alt="plus"/>
-                    </div>
-                    <span>상품을 선택해주세요.</span>
-                </styled.CompareItem>
-                <styled.CompareItem>
-                    <div>
-                        <img src={plus} alt="plus"/>
-                    </div>
-                    <span>상품을 선택해주세요.</span>
-                </styled.CompareItem>
+                {renderProductSelector(firstProduct, handleFirstProduct)}
+                {renderProductSelector(secondProduct, handleSecondProduct)}
             </styled.CompareContainer>
 
-            <h3>추천 상품</h3>
-				<styled.GridContainer>
-					{["추천 상품1", "추천 상품2"].map((name, index) => (
-						<styled.GridItem key={index}>
-							{name}
-						</styled.GridItem>
-					))}
+            {(firstProduct || secondProduct) ? (
+                <styled.CompareItemContainer>
+                    <CompareRow label="상품 유형" firstValue={firstProduct?.productType} secondValue={secondProduct?.productType} />
+                    <CompareRow label="수령 기간" firstValue={firstProduct?.rcvMethod} secondValue={secondProduct?.rcvMethod} />
+                    <CompareRow label="수수료 구조" firstValue={firstProduct?.feeType} secondValue={secondProduct?.feeType} />
+                    <CompareRow label="판매 여부" firstValue={firstProduct?.sells} secondValue={secondProduct?.sells} />
+                    <CompareRow label="중도 해지" firstValue={firstProduct?.withdraws} secondValue={secondProduct?.withdraws} />
+                    <CompareRow label="원금 보장" firstValue={firstProduct?.guarantees} secondValue={secondProduct?.guarantees} />
+                    <YearlyDataRow
+                        label="납입 원금"
+                        firstProduct={firstProduct}
+                        secondProduct={secondProduct}
+                        dataKey="Balance"
+                        suffix="원"
+                    />
+                    <YearlyDataRow
+                        label="적립금"
+                        firstProduct={firstProduct}
+                        secondProduct={secondProduct}
+                        dataKey="Reserve"
+                        suffix="원"
+                    />
+                    <YearlyDataRow
+                        label="수익률"
+                        firstProduct={firstProduct}
+                        secondProduct={secondProduct}
+                        dataKey="EarnRate"
+                        suffix="%"
+                    />
+                    <YearlyDataRow
+                        label="수수료율"
+                        firstProduct={firstProduct}
+                        secondProduct={secondProduct}
+                        dataKey="FeeRate"
+                        suffix="%"
+                    />
+                </styled.CompareItemContainer>
+            ) : (<>
+                <h3>하나은행 상품</h3>
+                <styled.GridContainer>
+                    {["추천 상품1", "추천 상품2"].map((name, index) => (
+                        <styled.GridItem key={index}>
+                            {name}
+                        </styled.GridItem>
+                    ))}
                 </styled.GridContainer>
-
+            </>)}
         </styled.Container>
     );
+
 }
 
 export default ProductComparePage;

--- a/src/pages/ProductPage/ProductSearch/ProductSearch.tsx
+++ b/src/pages/ProductPage/ProductSearch/ProductSearch.tsx
@@ -1,5 +1,5 @@
 import * as styled from "../styles";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 // components
@@ -22,19 +22,16 @@ const PRODUCT_LIST = [
 		id: 1,
 		bank: "하나은행",
 		title: "연금저축신탁 안정형 제1호",
-		image: img,
 	},
 	{
 		id: 2,
 		bank: "KB국민은행",
 		title: "연금저축신탁 안정형 제2호",
-		image: img,
 	},
 	{
 		id: 3,
 		bank: "신한은행",
 		title: "연금저축신탁 안정형 제3호",
-		image: img,
 	},
 	{
 		id: 4,
@@ -44,45 +41,68 @@ const PRODUCT_LIST = [
 	}
 ];
 
-function ProductSearch() {
-	const [activeTab, setActiveTab] = useState<'연금저축' | '퇴직연금'>('연금저축');
-	const navigate = useNavigate();
-	// const [searchTerm, setSearchTerm] = useState('');
+type ActiveTab = '연금저축' | '퇴직연금';
 
-	// const filteredProducts = PRODUCT_LIST.filter(product => 
-	// 	product.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-	// 	product.bank.toLowerCase().includes(searchTerm.toLowerCase())
-	// );
+function ProductSearch() {
+	const [activeTab, setActiveTab] = useState<ActiveTab>('연금저축');
+	const navigate = useNavigate();
+	const searchParams = new URLSearchParams(window.location.search);
+	const action = searchParams.get('action');
+	const firstProduct = searchParams.get('firstProduct');
+	const secondProduct = searchParams.get('secondProduct');
+	const activeType = searchParams.get('activeType');
+
+	useEffect(() => {
+		if (activeType) {
+			setActiveTab(activeType as ActiveTab);
+		}
+	}, [activeType]);
+
+	const handleItemClick = (id: number) => {
+		if (action === 'selectFirstProduct') {
+			// secondProduct가 이미 선택되어 있다면 유지
+			let query = `activeType=${activeTab}&firstProduct=${id}`;
+			if (secondProduct) {
+				query += `&secondProduct=${secondProduct}`;
+			}
+			navigate(`/product/compare?${query}`);
+		} else if (action === 'selectSecondProduct') {
+			// firstProduct가 이미 선택되어 있다면 유지
+			let query = `activeType=${activeTab}&secondProduct=${id}`;
+			if (firstProduct) {
+				query += `&firstProduct=${firstProduct}`;
+			}
+			navigate(`/product/compare?${query}`);
+		} else {
+			navigate(`/product/detail/${id}`);
+		}
+	};
 
 	return (
 		<styled.Container>
 			<Header title="상품 검색" />
-			
-			<SearchBar 
+
+			<SearchBar
 				placeholder="상품을 검색해 보세요!"
 			/>
 
-			<Tabs>
+			{!activeType && (<Tabs>
 				{TAB_DATA.map((tab) => (
-					<Tab 
+					<Tab
 						id={tab.id}
-						label={tab.label} 
-						isActive={activeTab === tab.id} 
+						label={tab.label}
+						isActive={activeTab === tab.id}
 						onClick={() => setActiveTab(tab.id)}
 					/>
 				))}
-			</Tabs>
-			
+			</Tabs>)}
+
 			{activeTab === '연금저축' && <Select items={['은행(신탁)', '자산운용(펀드)', '생명보험', '손해보험']} />}
 
 			<styled.ProductList>
 				{PRODUCT_LIST.map((product) => (
-					<styled.ProductItem key={product.id} onClick={() => navigate(`/product/detail/${product.id}`)}>
+					<styled.ProductItem key={product.id} onClick={() => handleItemClick(product.id)}>
 						<styled.ProductItemLeft>
-							<styled.ProductImage 
-								src={product.image} 
-								alt={product.title} 
-							/>
 							<styled.ProductInfo>
 								<styled.ProductSubTitle>{product.bank}</styled.ProductSubTitle>
 								<styled.ProductTitle>{product.title}</styled.ProductTitle>

--- a/src/pages/ProductPage/styles.tsx
+++ b/src/pages/ProductPage/styles.tsx
@@ -107,21 +107,23 @@ export const CompareItem = styled.div`
 	gap: 10px;
 	justify-content: center;
 	align-items: center;
+	text-align: center;
+`;
 
-	div {
-		background-color: white;
-		width: 100px;
-		height: 100px;
-		border-radius: 100%;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-	}
+export const CompareButton = styled.div`
+	background-color: white;
+	width: 100px;
+	height: 100px;
+	border-radius: 100%;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	
+`;
 
-	span {
-		font-size: 14px;
-		color: #878787;
-	}
+export const CompareButtonText = styled.span`
+	font-size: 14px;
+	color: #878787;
 `;
 
 export const TabContainer = styled.div`
@@ -139,9 +141,9 @@ export const TabText = styled.span<{ $active?: boolean }>`
 export const ProductList = styled.div`
 	display: flex;
 	flex-direction: column;
-	gap: 10px;
+	gap: 12px;
 	background-color: white;
-	padding: 10px;
+	padding: 16px;
 	border-radius: 12px;
 	max-height: 500px;
 	overflow-y: scroll;
@@ -185,4 +187,35 @@ export const ButtonContainer = styled.div`
 	justify-content: center;
 	padding: 10px 0;
 `;
-	
+
+export const CompareItemContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+`;
+
+export const CompareItemText = styled.p`
+	background-color: #E3EDF7;
+	text-align: center;
+	padding: 4px 10px;
+	border-radius: 8px;
+`;
+
+export const CompareItemTextContainer = styled.div`
+	display: flex;
+	p{
+		width: 100%;
+		text-align: center;
+		div{
+			display: flex;
+			gap: 8px;
+			justify-content: center;
+
+			span:first-child{
+				font-weight: bold;
+			}	
+		}
+	}
+`;
+
+

--- a/src/ui/BlueBtn.tsx
+++ b/src/ui/BlueBtn.tsx
@@ -44,6 +44,9 @@ const StyledBlueButton = styled.button<StyledButtonProps>`
 	color: white;
 	cursor: pointer;
 	border: none;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 
 	&:active {
 		background-color: #306394;

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -36,11 +36,12 @@ const SelectItem = styled.div`
 	}
 `;
 
-const Select = ({ items }: { items: string[] }) => {
+const Select = ({ items, onSelect }: { items: string[], onSelect?: (item: string) => void }) => {
     const [activeItem, setActiveItem] = useState(0);
 
     const handleClick = (index: number) => {
         setActiveItem(index);
+		onSelect?.(items[index]);
     };
 
     return (


### PR DESCRIPTION
ㅜㅡㅜ 상품 비교 페이지 <-> 상품 검색 페이지 연결하는 기능 추가했습니다....

넘 어려웠어여..........😭

1. 상품 비교 페이지에서 firstProduct 컴포넌트를 클릭하면
2. 상품 검색 페이지에서 firstProduct에 해당하는 아이템 선택
3. 상품 비교 페이지에서 해당 아이템을 뿌려줌
4. firstProduct가 선택되어 있는 상태에서 secondProduct 컴포넌트를 클릭하면
5. 상품 검색 페이지에서 firstProduct 정보를 저장한 채로 secondProduct에 해당하는 아이템 선택
6. 상품 비교 페이지에서 firstProduct와 secondProduct 아이템을 같이 보여줌
7. 비교하기 전 연금저축/퇴직연금 상품 선택한 값도 함께 저장해두고 사용
8. secondProduct와 firstProduct의 순서를 반대로 선택해도 가능

- firstProduct 또는 secondProduct를 수정하는 로직이 필요한지 확인 필요