### PR TITLE
🩹 [fix] 현금 조회/수정 오류 수정

### DIFF
--- a/src/pages/AssetPage/AssetDetailPage/AssetDetailPage.tsx
+++ b/src/pages/AssetPage/AssetDetailPage/AssetDetailPage.tsx
@@ -163,7 +163,7 @@ function Cash() {
         async function getCash() {
             const response = await assetService.getCash();
             if (response?.data) {
-                setCash(response.data.result);
+                setCash(response.data.result.amount);
             }
         }
         getCash();
@@ -306,9 +306,11 @@ function Pension() {
 
 function AssetDetailPage() {
     const { label } = useParams();
+    const navigate = useNavigate();
+    
     return (
         <styled.Container>
-            <Header title={label || ""} showClose={true} />
+            <Header title={label || ""} showClose={true} onClose={()=>navigate("/asset/list")} />
             <styled.IconWrapper>
                 <img 
                     src={ASSET_DATA.find(item => item.label === label)?.icon} 

--- a/src/pages/AssetPage/AssetModifyPage/AssetModifyPage.tsx
+++ b/src/pages/AssetPage/AssetModifyPage/AssetModifyPage.tsx
@@ -1,6 +1,6 @@
 import * as styled from "../styles";
 import { useParams } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 // components
@@ -13,17 +13,27 @@ import { assetService } from "../../../services/api/Asset";
 
 function AssetModifyPage() {
     const { label } = useParams(); 
-    const [value, setValue] = useState<number>(0);
     const navigate = useNavigate();
+    const [cash, setCash] = useState<number | ''>(0);
+
+    useEffect(() => {
+        async function getCash() {
+            const response = await assetService.getCash();
+            if (response?.data) {
+                setCash(response.data.result.amount);
+            }
+        }
+        getCash();
+    }, []);
 
     const handleModify = async (value: number) => {
-        const response = await assetService.patchCash({amount:value});
+        const response = await assetService.patchCash({amount: value});
         if (response?.data) {
             if(response.data.code === "COMMON200") {
                 navigate(`/asset/detail/${label}`);
             }
         }
-        }
+    }
 
     return (
         <styled.Container>
@@ -33,10 +43,10 @@ function AssetModifyPage() {
                 type="number"
                 placeholder="보유한 돈"
                 suffix="원"
-                value={value}
-                onChange={(e) => setValue(Number(e.target.value))}
+                value={cash === 0 ? '' : cash}
+                onChange={(e) => setCash(e.target.value === '' ? '' : Number(e.target.value))}
             />
-            <BlueButton variant="large"onClick={() => handleModify(value)}>저장하기</BlueButton>
+            <BlueButton variant="large" onClick={() => handleModify(cash || 0)}>저장하기</BlueButton>
         </styled.Container>
     );
 } 

--- a/src/services/api/Asset.ts
+++ b/src/services/api/Asset.ts
@@ -80,8 +80,8 @@ export const assetService = {
       url: `${BASE_URL}/asset/cash`,
     });
   },
-  patchCash: (data: dto.CashRequestDTO) => {
-    return request<dto.CashResponseDTO>({
+  patchCash: (data: dto.PatchCashRequestDTO) => {
+    return request<dto.PatchCashResponstDTO>({
       method: 'PATCH',
       url: `${BASE_URL}/asset/cash`,
       data,

--- a/src/services/dto/Asset.ts
+++ b/src/services/dto/Asset.ts
@@ -163,9 +163,16 @@ export interface BanksResponseDTO {
 export interface CashResponseDTO {
     code: string;
     message: string;
+	result: {
+		id: string;
+		amount: number;
+	};
+}
+export interface PatchCashResponstDTO{
+	code: string;
+    message: string;
 	result: number;
 }
-
-export interface CashRequestDTO {
+export interface PatchCashRequestDTO {
     amount: number;
 }


### PR DESCRIPTION
1. 현금 조회시 DTO 수정
2. 현금 수정 시 빈 문자열 허용 처리 (AssetModifyPage.tsx)
3. 수정 완료 후 'x' 버튼으로 창 닫으면 '/asset/list'로 이동하도록 수정