### PR TITLE
🐛 [fix] 상품 비교 페이지 중 상품 상세 오류 수정

### DIFF
--- a/src/pages/ProductPage/components/ProductSelector.tsx
+++ b/src/pages/ProductPage/components/ProductSelector.tsx
@@ -26,7 +26,7 @@ function ProductSelector({ product, onClick }: ProductSelectorProps) {
                     <p style={{ width: "100%", wordBreak: "keep-all", overflowWrap: "break-word", height: "70px" }}>
                         {'product' in product ? product.product : product.company}
                     </p>
-                    <BlueButton variant="small" style={{ width: "100px" }} onClick={() => navigate(`/product/detail/${product?.productId || product?.companyId}`)}>
+                    <BlueButton variant="small" style={{ width: "100px" }} onClick={() => navigate(`/product/detail/${product?.productId || product?.companyId}?activeType=${'product' in product ?'연금저축':'퇴직연금'}`)}>
                         상품 상세
                     </BlueButton>
                 </>


### PR DESCRIPTION
상품 비교 페이지에서 "상품 상세" 버튼 클릭 시 오류 해결

- 오류 원인: [퇴직연금] 선택 시에도 [연금저축] API를 부르고 있음
- 해결 방법: "상품 상세" 버튼 클릭 시 [연금저축]/[퇴직연금] 선택을 확인한 뒤 해당 API를 요청