### PR TITLE
⚡️ [improve] 검색 성능 개선을 위해 드바운스 사용

### DIFF
--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+    const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => {
+            clearTimeout(timer);
+        };
+    }, [value, delay]);
+
+    return debouncedValue;
+} 


### PR DESCRIPTION
1. 사용자가 타이핑을 멈추고 500ms가 지난 후에만 API를 호출합니다.
2. 불필요한 API 호출이 줄어들어 서버 부하가 감소합니다.
3. 사용자 입력에 대한 반응성은 유지하면서도 성능이 개선됩니다.
4. 검색 버튼을 클릭했을 때는 즉시 검색이 실행되고, 타이핑할 때는 디바운스된 검색이 실행되어 더 효율적인 검색 기능을 제공할 수 있습니다.